### PR TITLE
Add a11y anchor, correct link to a11y page

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -155,7 +155,7 @@ heading: About DjangoCon US
           <svg class="card-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 93.08 108.87"><defs><style>.cls-1{fill:#231f20;}</style></defs><title>globe</title><g id="Layer_2" data-name="Layer 2"><g id="callouts"><path class="cls-1" d="M93.08,41.87a53,53,0,0,0-19-40.7,5,5,0,0,0-6.42,7.66,43.08,43.08,0,0,1-27,76.1,3.18,3.18,0,0,0-1.27,0,42.91,42.91,0,0,1-22.46-6.67,5,5,0,0,0-5.36,8.44,52.84,52.84,0,0,0,23.43,8v4.16H13a5,5,0,1,0,0,10H66a5,5,0,1,0,0-10H45V94.71A53.15,53.15,0,0,0,93.08,41.87Z"/><path class="cls-1" d="M40,81.87a40,40,0,1,0-40-40A40,40,0,0,0,40,81.87Zm0-70a30,30,0,1,1-30,30A30,30,0,0,1,40,11.87Z"/></g></g></svg>
           <div class="card-section">
             <h3 class="card-title" id="commitment-to-diversity">Commitment to Diversity</h3>
-            <p>It is a core aim of DjangoCon US 2017 to encourage diversity, enforce our <a href="/about/coc/">Code of Conduct</a>, and make our event as inclusive and <a href="/about/accessibility/">accessible</a> as possible.</p>
+            <p>It is a core aim of DjangoCon US 2017 to encourage diversity, enforce our <a href="/about/coc/">Code of Conduct</a>, and make our event as inclusive and <a href="/venue#accessibility">accessible</a> as possible.</p>
           </div>
         </div>
       </div>

--- a/_pages/venue.html
+++ b/_pages/venue.html
@@ -173,7 +173,7 @@ heading: Venue
 <div class="section-pad theme-dark-green">
   <div class="row">
     <div class="column medium-5">
-      <h2>An Accessible Experience</h2>
+      <h2 id="accessibility">An Accessible Experience</h2>
       <p class="lead min">We've worked with the staff at Hotel RL to accommodate the diverse needs of our attendees.</p>
       <p>Are we missing something? <strong><a href="mailto:hello@djangocon.us">Let us know</a></strong></p>
     </div>


### PR DESCRIPTION
Creates anchor for accessibility section on Venue page; corrects link on About page to go to Accessibility anchor on venue. 