### PR TITLE
Replace lorem ipsum, link to sponsor info page instead of to prospectus

### DIFF
--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -15,14 +15,14 @@ description: DjangoCon US is only possible through the support of various organi
   <div class="row column v-pad-bottom">
     <div class="medium-6 large-7 column">
       <p class="lead">
-        DjangoCon US is only possible through the support of various organizations. Suspendisse vel sapien eget sapien elementum varius. Curabitur non urna vel velit consectetur lobortis. Morbi scelerisque erat vitae ante ullamcorper posuere. Aenean fringilla, quam quis laoreet ultrices.
+        DjangoCon US is only possible through the generosity of the organizations and businesses on this page. Their donations make it possible for us to provide financial support to speakers and attendees, record all talks, host sprints, and feed everyone for six days. Thank you for your support! 
       </p>
     </div>
     <div class="medium-5 large-4 column">
       <div class="callout callout-dark text-center sponsor-cta-box">
         <h2>Sponsor DjangoCon US</h2>
         <p>By supporting the community who builds and supports the software you use, you help ensure its happiness, health, and productivity.</p>
-        <a href="{{ site.sponsorship_prospectus }}" class="button secondary">Become a Sponsor</a>
+        <a href="/sponsors/information/" class="button secondary">Become a Sponsor</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The sponsors page linked directly to the sponsorship prospectus and not to the info page. I linked to the info page, but we can (should?) add a link to the prospectus from the info page. 