### PR TITLE
Fixes sponsors being blocked by common ad blockers

### DIFF
--- a/_includes/sponsor-footer.html
+++ b/_includes/sponsor-footer.html
@@ -1,16 +1,16 @@
-<div class="sponsor-footer section-pad theme-light-beige">
+<div class="partner-footer section-pad theme-light-beige">
   <h3 class="v-pad-bottom text-center">Our Sponsors</h3>
 
   {% for level in site.data.sponsors.levels %}
     {% if level.sponsors %}
       <h4 class="lead min text-center swatch-color-teal">{{ level.name }}</h4>
-      <div class="row sponsor-list">
+      <div class="row partner-list">
         {% for sponsor in level.sponsors %}
           {% unless sponsor.hidden %}
-            <div class="sponsor-block text-center">
+            <div class="partner-block text-center">
               <a href="{{ sponsor.url }}">
                 <img
-                  class="sponsor-logo {{ sponsor.logo_orientation }}"
+                  class="partner-logo {{ sponsor.logo_orientation }}"
                   src="{{ sponsor.logo }}"
                   alt="{{ sponsor.name }} Logo" />
               </a>

--- a/_layouts/home-full.html
+++ b/_layouts/home-full.html
@@ -188,7 +188,7 @@ layout: base
   <section class="home-sponsors section-pad theme-light-beige">
     <div class="row">
       <div class="column medium-6">
-        <ul class="sponsor-list">
+        <ul class="partner-list">
           <li class="item"><a class="sponsor" href="#"><img src="http://placehold.it/100x100/75cdd6/fff?text=logo"></a></li>
           <li class="item"><a class="sponsor" href="#"><img src="http://placehold.it/200x175/0c4b33/fff?text=logo"></a></li>
           <li class="item"><a class="sponsor" href="#"><img src="http://placehold.it/200x100/d66315/fff?text=logo"></a></li>

--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -15,11 +15,11 @@ description: DjangoCon US is only possible through the support of various organi
   <div class="row column v-pad-bottom">
     <div class="medium-6 large-7 column">
       <p class="lead">
-        DjangoCon US is only possible through the generosity of the organizations and businesses on this page. Their donations make it possible for us to provide financial support to speakers and attendees, record all talks, host sprints, and feed everyone for six days. Thank you for your support! 
+        DjangoCon US is only possible through the generosity of the organizations and businesses on this page. Their donations make it possible for us to provide financial support to speakers and attendees, record all talks, host sprints, and feed everyone for six days. Thank you for your support!
       </p>
     </div>
     <div class="medium-5 large-4 column">
-      <div class="callout callout-dark text-center sponsor-cta-box">
+      <div class="callout callout-dark text-center partner-cta-box">
         <h2>Sponsor DjangoCon US</h2>
         <p>By supporting the community who builds and supports the software you use, you help ensure its happiness, health, and productivity.</p>
         <a href="/sponsors/information/" class="button secondary">Become a Sponsor</a>
@@ -33,18 +33,18 @@ description: DjangoCon US is only possible through the support of various organi
         <h2 class="text-center v-pad-bottom">{{ level.name }}</h2>
         {% for sponsor in level.sponsors %}
           {% unless sponsor.hidden %}
-            <div class="row sponsor">
+            <div class="row partner">
               <div class="column medium-4 text-center">
                 <a href="{{ sponsor.url }}">
                   <img
-                    class="sponsor-logo {{ sponsor.logo_orientation }}"
+                    class="partner-logo {{ sponsor.logo_orientation }}"
                     src="{{ sponsor.logo }}"
                     alt="{{ sponsor.name }} Logo" />
                 </a>
               </div>
               <div class="column medium-8">
-                <h3 class="sponsor-name"><a href="{{ sponsor.url }}">{{ sponsor.name }}</a></h3>
-                <p class="sponsor-description">{{ sponsor.description }}</p>
+                <h3 class="partner-name"><a href="{{ sponsor.url }}">{{ sponsor.name }}</a></h3>
+                <p class="partner-description">{{ sponsor.description }}</p>
               </div>
             </div>
           {% endunless %}

--- a/_scss/layout/_layouts.scss
+++ b/_scss/layout/_layouts.scss
@@ -1,6 +1,6 @@
 // Patterns that are specific to a page and likely not reusable.
 
-.sponsor-cta-box h2 {
+.partner-cta-box h2 {
   margin-bottom: $global-margin / 2;
   font-size: rem-calc(28);
 }

--- a/_scss/module/_home-sponsors.scss
+++ b/_scss/module/_home-sponsors.scss
@@ -1,16 +1,16 @@
-.sponsor-list {
-  list-style: none;
+.partner-list {
   margin: 0;
   padding: 0;
   text-align: center;
+  list-style: none;
 
   .item {
     display: inline-block;
-    max-width: 200px;
     margin: 0.5em;
+    max-width: 200px;
   }
 
-  .sponsor {
+  .partner {
     display: block;
     opacity: 0.7;
     transition: all 300ms ease;

--- a/_scss/module/_sponsor-footer.scss
+++ b/_scss/module/_sponsor-footer.scss
@@ -1,4 +1,4 @@
-.sponsor-footer {
+.partner-footer {
   h3 {
     @extend h2;
     margin-bottom: $global-margin * 2;
@@ -10,7 +10,7 @@
     text-transform: uppercase;
   }
 
-  .sponsor-list {
+  .partner-list {
     position: relative;
     margin-bottom: $global-margin * 2;
 
@@ -26,13 +26,13 @@
   }
 }
 
-.sponsor-list {
+.partner-list {
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
 }
 
-.sponsor-block {
+.partner-block {
   padding: 0 $global-margin $global-margin;
   width: 100%;
 
@@ -49,12 +49,12 @@
   }
 }
 
-.sponsor-list {
-  .sponsor-logo.portrait {
+.partner-list {
+  .partner-logo.portrait {
     max-height: 70px;
   }
 
-  .sponsor-logo.landscape {
+  .partner-logo.landscape {
     max-width: 160px;
   }
 }
@@ -62,7 +62,7 @@
 
 /*
 // LEGACY
-.sponsor-list {
+.partner-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -74,7 +74,7 @@
     margin: 0.5em;
   }
 
-  .sponsor {
+  .partner {
     display: block;
     opacity: 0.7;
     transition: all 300ms ease;

--- a/_scss/module/_sponsors.scss
+++ b/_scss/module/_sponsors.scss
@@ -1,25 +1,25 @@
-.sponsor {
+.partner {
   margin-bottom: $global-margin * 2;
 }
 
-.sponsor-name {
+.partner-name {
   font-size: rem-calc(36);
   font-weight: $global-weight-normal;
 }
 
-.sponsor-url {
+.partner-url {
   font-size: rem-calc(20);
   font-weight: $global-weight-normal;
 }
 
-.sponsor-logo {
+.partner-logo {
   margin-bottom: $global-margin;
 }
 
-.sponsor-logo.portrait {
+.partner-logo.portrait {
   max-height: 200px;
 }
 
-.sponsor-logo.landscape {
+.partner-logo.landscape {
   max-width: 300px;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -224,15 +224,15 @@ button{padding:0;-webkit-appearance:none;-moz-appearance:none;appearance:none;bo
 .large-uncentered,.large-push-0,.large-pull-0{position:static;float:left;margin-right:0;margin-left:0}
 }.column-block{margin-bottom:.96154rem}.column-block>:last-child{margin-bottom:0}
 @media print,screen and (min-width:55.625em){.column-block{margin-bottom:1.44231rem}
-.column-block>:last-child{margin-bottom:0}}div,dl,dt,dd,ul,ol,li,h1,h2,.sponsor-footer h3,h3,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+.column-block>:last-child{margin-bottom:0}}div,dl,dt,dd,ul,ol,li,h1,h2,.partner-footer h3,h3,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 p{margin-bottom:1rem;font-size:inherit;line-height:1.6;text-rendering:optimizeLegibility}
 em,i{font-style:italic;line-height:inherit}strong,b{font-weight:500;line-height:inherit}
-small{font-size:80%;line-height:inherit}h1,h2,.sponsor-footer h3,h3,h4,h5,h6{font-family:"program",Helvetica,sans-serif;font-style:normal;font-weight:500;color:inherit;text-rendering:optimizeLegibility}
-h1 small,h2 small,.sponsor-footer h3 small,h3 small,h4 small,h5 small,h6 small{line-height:0;color:#68866e}
-h1{font-size:1.63462rem;line-height:1.2;margin-top:0;margin-bottom:1rem}h2,.sponsor-footer h3{font-size:1.63462rem;line-height:1.2;margin-top:0;margin-bottom:1rem}
+small{font-size:80%;line-height:inherit}h1,h2,.partner-footer h3,h3,h4,h5,h6{font-family:"program",Helvetica,sans-serif;font-style:normal;font-weight:500;color:inherit;text-rendering:optimizeLegibility}
+h1 small,h2 small,.partner-footer h3 small,h3 small,h4 small,h5 small,h6 small{line-height:0;color:#68866e}
+h1{font-size:1.63462rem;line-height:1.2;margin-top:0;margin-bottom:1rem}h2,.partner-footer h3{font-size:1.63462rem;line-height:1.2;margin-top:0;margin-bottom:1rem}
 h3{font-size:1.15385rem;line-height:1.2;margin-top:0;margin-bottom:1rem}h4{font-size:.96154rem;line-height:1.2;margin-top:0;margin-bottom:1rem}
 h5{font-size:.81731rem;line-height:1.2;margin-top:0;margin-bottom:1rem}h6{font-size:.76923rem;line-height:1.2;margin-top:0;margin-bottom:1rem}
-@media print,screen and (min-width:55.625em){h1{font-size:2.30769rem}h2,.sponsor-footer h3{font-size:2.11538rem}
+@media print,screen and (min-width:55.625em){h1{font-size:2.30769rem}h2,.partner-footer h3{font-size:2.11538rem}
 h3{font-size:1.49038rem}h4{font-size:1.20192rem}h5{font-size:.96154rem}h6{font-size:.76923rem}
 }a{line-height:inherit;color:#0c4b33;text-decoration:underline;cursor:pointer}a:hover,a:focus{color:#0a412c;text-decoration:none}
 a img{border:0}hr{clear:both;max-width:57.69231rem;height:0;margin:.96154rem auto;border-top:0;border-right:0;border-bottom:1px solid #cacaca;border-left:0}
@@ -260,8 +260,8 @@ a,a:visited{text-decoration:underline}a[href]:after{content:" (" attr(href) ")"}
 .ir a:after,a[href^='javascript:']:after,a[href^='#']:after{content:''}
 abbr[title]:after{content:" (" attr(title) ")"}
 pre,blockquote{border:1px solid #8a8a8a;page-break-inside:avoid}thead{display:table-header-group}
-tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:.5cm}p,h2,.sponsor-footer h3,h3{orphans:3;widows:3}
-h2,.sponsor-footer h3,h3{page-break-after:avoid}}.button{display:inline-block;vertical-align:middle;margin:0 0 1rem 0;padding:.85em 1em;-webkit-appearance:none;border:1px solid transparent;border-radius:0;transition:background-color .25s ease-out,color .25s ease-out;font-size:.9rem;line-height:1;text-align:center;cursor:pointer;background-color:#0c4b33;color:#fefefe}
+tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:.5cm}p,h2,.partner-footer h3,h3{orphans:3;widows:3}
+h2,.partner-footer h3,h3{page-break-after:avoid}}.button{display:inline-block;vertical-align:middle;margin:0 0 1rem 0;padding:.85em 1em;-webkit-appearance:none;border:1px solid transparent;border-radius:0;transition:background-color .25s ease-out,color .25s ease-out;font-size:.9rem;line-height:1;text-align:center;cursor:pointer;background-color:#0c4b33;color:#fefefe}
 [data-whatinput='mouse'] .button{outline:0}.button:hover,.button:focus{background-color:#0a402b;color:#fefefe}
 .button.tiny{font-size:.6rem}.button.small{font-size:.75rem}.button.large{font-size:1.25rem}
 .button.expanded{display:block;width:100%;margin-right:0;margin-left:0}.button.primary{background-color:#0c4b33;color:#fefefe}
@@ -716,42 +716,42 @@ a.thumbnail image{box-shadow:none}.title-bar{padding:0;background:rgba(12,75,51,
 }.theme-light-beige{background-color:#f8efe3}.theme-light-beige .theme-color{color:#f8efe3}
 .tint-light-beige{position:relative}@media print,screen and (min-width:55.625em){.tint-light-beige:after{position:absolute;top:0;right:0;bottom:0;left:0;background-color:#f8efe3;content:"";opacity:.8}
 }.swatch-color-green{color:#0c4b33}.card-theme-green{border:0;border-top:8px solid #0c4b33}
-.card-theme-green h1,.card-theme-green h2,.card-theme-green .sponsor-footer h3,.sponsor-footer .card-theme-green h3,.card-theme-green h3,.card-theme-green h4,.card-theme-green h5,.card-theme-green h6,.card-theme-green a{color:#0c4b33}
+.card-theme-green h1,.card-theme-green h2,.card-theme-green .partner-footer h3,.partner-footer .card-theme-green h3,.card-theme-green h3,.card-theme-green h4,.card-theme-green h5,.card-theme-green h6,.card-theme-green a{color:#0c4b33}
 .card-theme-green a:hover{color:#0b442e}.card-theme-green .theme-color{color:#0c4b33}
 .card-theme-green .theme-bg{background-color:#0c4b33;color:#fff}.card-theme-green path{fill:#0c4b33}
 .swatch-color-light-green{color:#20c989}.card-theme-light-green{border:0;border-top:8px solid #20c989}
-.card-theme-light-green h1,.card-theme-light-green h2,.card-theme-light-green .sponsor-footer h3,.sponsor-footer .card-theme-light-green h3,.card-theme-light-green h3,.card-theme-light-green h4,.card-theme-light-green h5,.card-theme-light-green h6,.card-theme-light-green a{color:#20c989}
+.card-theme-light-green h1,.card-theme-light-green h2,.card-theme-light-green .partner-footer h3,.partner-footer .card-theme-light-green h3,.card-theme-light-green h3,.card-theme-light-green h4,.card-theme-light-green h5,.card-theme-light-green h6,.card-theme-light-green a{color:#20c989}
 .card-theme-light-green a:hover{color:#1db57b}.card-theme-light-green .theme-color{color:#20c989}
 .card-theme-light-green .theme-bg{background-color:#20c989;color:#fff}.card-theme-light-green path{fill:#20c989}
 .swatch-color-dark-green{color:#0a402b}.card-theme-dark-green{border:0;border-top:8px solid #0a402b}
-.card-theme-dark-green h1,.card-theme-dark-green h2,.card-theme-dark-green .sponsor-footer h3,.sponsor-footer .card-theme-dark-green h3,.card-theme-dark-green h3,.card-theme-dark-green h4,.card-theme-dark-green h5,.card-theme-dark-green h6,.card-theme-dark-green a{color:#0a402b}
+.card-theme-dark-green h1,.card-theme-dark-green h2,.card-theme-dark-green .partner-footer h3,.partner-footer .card-theme-dark-green h3,.card-theme-dark-green h3,.card-theme-dark-green h4,.card-theme-dark-green h5,.card-theme-dark-green h6,.card-theme-dark-green a{color:#0a402b}
 .card-theme-dark-green a:hover{color:#093a27}.card-theme-dark-green .theme-color{color:#0a402b}
 .card-theme-dark-green .theme-bg{background-color:#0a402b;color:#fff}.card-theme-dark-green path{fill:#0a402b}
 .swatch-color-teal{color:#3b928f}.card-theme-teal{border:0;border-top:8px solid #3b928f}
-.card-theme-teal h1,.card-theme-teal h2,.card-theme-teal .sponsor-footer h3,.sponsor-footer .card-theme-teal h3,.card-theme-teal h3,.card-theme-teal h4,.card-theme-teal h5,.card-theme-teal h6,.card-theme-teal a{color:#3b928f}
+.card-theme-teal h1,.card-theme-teal h2,.card-theme-teal .partner-footer h3,.partner-footer .card-theme-teal h3,.card-theme-teal h3,.card-theme-teal h4,.card-theme-teal h5,.card-theme-teal h6,.card-theme-teal a{color:#3b928f}
 .card-theme-teal a:hover{color:#358381}.card-theme-teal .theme-color{color:#3b928f}
 .card-theme-teal .theme-bg{background-color:#3b928f;color:#fff}.card-theme-teal path{fill:#3b928f}
 .swatch-color-light-blue{color:#84d3d5}.card-theme-light-blue{border:0;border-top:8px solid #84d3d5}
-.card-theme-light-blue h1,.card-theme-light-blue h2,.card-theme-light-blue .sponsor-footer h3,.sponsor-footer .card-theme-light-blue h3,.card-theme-light-blue h3,.card-theme-light-blue h4,.card-theme-light-blue h5,.card-theme-light-blue h6,.card-theme-light-blue a{color:#84d3d5}
+.card-theme-light-blue h1,.card-theme-light-blue h2,.card-theme-light-blue .partner-footer h3,.partner-footer .card-theme-light-blue h3,.card-theme-light-blue h3,.card-theme-light-blue h4,.card-theme-light-blue h5,.card-theme-light-blue h6,.card-theme-light-blue a{color:#84d3d5}
 .card-theme-light-blue a:hover{color:#77bec0}.card-theme-light-blue .theme-color{color:#84d3d5}
 .card-theme-light-blue .theme-bg{background-color:#84d3d5;color:#fff}.card-theme-light-blue path{fill:#84d3d5}
 .swatch-color-orange{color:#d66315}.card-theme-orange{border:0;border-top:8px solid #d66315}
-.card-theme-orange h1,.card-theme-orange h2,.card-theme-orange .sponsor-footer h3,.sponsor-footer .card-theme-orange h3,.card-theme-orange h3,.card-theme-orange h4,.card-theme-orange h5,.card-theme-orange h6,.card-theme-orange a{color:#d66315}
+.card-theme-orange h1,.card-theme-orange h2,.card-theme-orange .partner-footer h3,.partner-footer .card-theme-orange h3,.card-theme-orange h3,.card-theme-orange h4,.card-theme-orange h5,.card-theme-orange h6,.card-theme-orange a{color:#d66315}
 .card-theme-orange a:hover{color:#c15913}.card-theme-orange .theme-color{color:#d66315}
 .card-theme-orange .theme-bg{background-color:#d66315;color:#fff}.card-theme-orange path{fill:#d66315}
 .swatch-color-dark-beige{color:#e5d4bd}.card-theme-dark-beige{border:0;border-top:8px solid #e5d4bd}
-.card-theme-dark-beige h1,.card-theme-dark-beige h2,.card-theme-dark-beige .sponsor-footer h3,.sponsor-footer .card-theme-dark-beige h3,.card-theme-dark-beige h3,.card-theme-dark-beige h4,.card-theme-dark-beige h5,.card-theme-dark-beige h6,.card-theme-dark-beige a{color:#e5d4bd}
+.card-theme-dark-beige h1,.card-theme-dark-beige h2,.card-theme-dark-beige .partner-footer h3,.partner-footer .card-theme-dark-beige h3,.card-theme-dark-beige h3,.card-theme-dark-beige h4,.card-theme-dark-beige h5,.card-theme-dark-beige h6,.card-theme-dark-beige a{color:#e5d4bd}
 .card-theme-dark-beige a:hover{color:#cebfaa}.card-theme-dark-beige .theme-color{color:#e5d4bd}
 .card-theme-dark-beige .theme-bg{background-color:#e5d4bd;color:#fff}.card-theme-dark-beige path{fill:#e5d4bd}
 .swatch-color-light-beige{color:#f8efe3}.card-theme-light-beige{border:0;border-top:8px solid #f8efe3}
-.card-theme-light-beige h1,.card-theme-light-beige h2,.card-theme-light-beige .sponsor-footer h3,.sponsor-footer .card-theme-light-beige h3,.card-theme-light-beige h3,.card-theme-light-beige h4,.card-theme-light-beige h5,.card-theme-light-beige h6,.card-theme-light-beige a{color:#f8efe3}
+.card-theme-light-beige h1,.card-theme-light-beige h2,.card-theme-light-beige .partner-footer h3,.partner-footer .card-theme-light-beige h3,.card-theme-light-beige h3,.card-theme-light-beige h4,.card-theme-light-beige h5,.card-theme-light-beige h6,.card-theme-light-beige a{color:#f8efe3}
 .card-theme-light-beige a:hover{color:#dfd7cc}.card-theme-light-beige .theme-color{color:#f8efe3}
 .card-theme-light-beige .theme-bg{background-color:#f8efe3;color:#fff}.card-theme-light-beige path{fill:#f8efe3}
 .bottomless>*:last-child{margin-bottom:0}.v-pad-bottom{padding-bottom:1rem}@media print,screen and (min-width:55.625em){.v-pad-bottom{padding-bottom:2rem}
 }.v-pad-top{padding-top:1rem}@media print,screen and (min-width:55.625em){.v-pad-top{padding-top:2rem}
 }.section-pad{padding-top:1rem;padding-bottom:1rem}@media print,screen and (min-width:55.625em){.section-pad{padding-top:4rem;padding-bottom:4rem}
-}.wf-loading h1,.wf-loading h2,.wf-loading .sponsor-footer h3,.sponsor-footer .wf-loading h3,.wf-loading h3,.wf-loading h4,.wf-loading h5,.wf-loading h6,.wf-loading p,.wf-loading li,.wf-loading table{visibility:hidden}
-h1 a,h2 a,.sponsor-footer h3 a,h3 a,h4 a,h5 a,h6 a{text-decoration:none}li{margin-bottom:.85rem}
+}.wf-loading h1,.wf-loading h2,.wf-loading .partner-footer h3,.partner-footer .wf-loading h3,.wf-loading h3,.wf-loading h4,.wf-loading h5,.wf-loading h6,.wf-loading p,.wf-loading li,.wf-loading table{visibility:hidden}
+h1 a,h2 a,.partner-footer h3 a,h3 a,h4 a,h5 a,h6 a{text-decoration:none}li{margin-bottom:.85rem}
 .lead{margin-bottom:2.5rem;font-weight:400}.lead.min{margin-bottom:1.5rem}.demp{font-weight:400}
 iframe,.highlighter-rouge{margin-bottom:1rem}.responsive-embed iframe{margin-bottom:0}
 .thumbnail-block{border-radius:0}@media print,screen and (min-width:55.625em){.list-split{display:-ms-flexbox;display:flex;-ms-flex-flow:row wrap;flex-flow:row wrap;-ms-flex-pack:justify;justify-content:space-between}
@@ -791,7 +791,7 @@ iframe,.highlighter-rouge{margin-bottom:1rem}.responsive-embed iframe{margin-bot
 .footer-logo:hover .djangocon{fill:#0c4b33}@media print,screen and (min-width:55.625em){.footer-logo{margin-top:-44px}
 }.footer-nav{list-style:none;margin:0;padding:0;font-weight:bold;font-size:1.15385rem}
 .footer-nav a{color:#fefefe;display:block;padding:.25em .5em}@media print,screen and (min-width:55.625em){.footer-nav{text-align:center}
-.footer-nav li{display:inline-block;vertical-align:baseline}}.sponsor-cta-box h2,.sponsor-cta-box .sponsor-footer h3,.sponsor-footer .sponsor-cta-box h3{margin-bottom:.5rem;font-size:1.34615rem}
+.footer-nav li{display:inline-block;vertical-align:baseline}}.partner-cta-box h2,.partner-cta-box .partner-footer h3,.partner-footer .partner-cta-box h3{margin-bottom:.5rem;font-size:1.34615rem}
 .schedule-page .subpage-content{padding-bottom:0}.attraction-name{margin-bottom:.5rem}
 .attraction-location{font-size:.8rem}.attraction-location .label{margin-right:1rem;font-size:.8em;font-weight:500}
 .attraction-description{max-width:24em;font-size:.9rem}@media print,screen and (min-width:64em){.attraction-list .column,.attraction-list .columns{margin-bottom:2.5rem}
@@ -862,14 +862,14 @@ iframe,.highlighter-rouge{margin-bottom:1rem}.responsive-embed iframe{margin-bot
 .events{display:-ms-flexbox;display:flex}.event{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;margin:0 .5rem;text-align:left;-ms-flex-positive:1;flex-grow:1}
 .event:first-child{margin-left:0}.event:last-child{margin-right:0}.event .label{display:inline-block;-ms-flex-item-align:start;align-self:flex-start;margin-left:0}
 .time{margin-bottom:0;text-align:right}.time .muted{display:block;opacity:.6}.time .muted:before{content:""}
-}.sponsor{margin-bottom:2rem}.sponsor-name{font-size:1.73077rem;font-weight:400}.sponsor-url{font-size:.96154rem;font-weight:400}
-.sponsor-logo{margin-bottom:1rem}.sponsor-logo.portrait{max-height:200px}.sponsor-logo.landscape{max-width:300px}
-.sponsor-footer h3{margin-bottom:2rem}.sponsor-footer .lead{font-size:.96154rem;font-weight:500;text-transform:uppercase}
-.sponsor-footer .sponsor-list{position:relative;margin-bottom:2rem}.sponsor-footer .sponsor-list:not(:last-child):after{position:absolute;bottom:0;display:block;width:80%;height:1px;background:#e5d4bd;content:""}
-.sponsor-list{display:-ms-flexbox;display:flex;-ms-flex-flow:row wrap;flex-flow:row wrap;-ms-flex-pack:center;justify-content:center}
-.sponsor-block{padding:0 1rem 1rem;width:100%}@media screen and (min-width:32.75em){.sponsor-block{width:33.33%}
-}@media print,screen and (min-width:55.625em){.sponsor-block{width:25%}}@media print,screen and (min-width:64em){.sponsor-block{width:20%}
-}.sponsor-list .sponsor-logo.portrait{max-height:70px}.sponsor-list .sponsor-logo.landscape{max-width:160px}
+}.partner{margin-bottom:2rem}.partner-name{font-size:1.73077rem;font-weight:400}.partner-url{font-size:.96154rem;font-weight:400}
+.partner-logo{margin-bottom:1rem}.partner-logo.portrait{max-height:200px}.partner-logo.landscape{max-width:300px}
+.partner-footer h3{margin-bottom:2rem}.partner-footer .lead{font-size:.96154rem;font-weight:500;text-transform:uppercase}
+.partner-footer .partner-list{position:relative;margin-bottom:2rem}.partner-footer .partner-list:not(:last-child):after{position:absolute;bottom:0;display:block;width:80%;height:1px;background:#e5d4bd;content:""}
+.partner-list{display:-ms-flexbox;display:flex;-ms-flex-flow:row wrap;flex-flow:row wrap;-ms-flex-pack:center;justify-content:center}
+.partner-block{padding:0 1rem 1rem;width:100%}@media screen and (min-width:32.75em){.partner-block{width:33.33%}
+}@media print,screen and (min-width:55.625em){.partner-block{width:25%}}@media print,screen and (min-width:64em){.partner-block{width:20%}
+}.partner-list .partner-logo.portrait{max-height:70px}.partner-list .partner-logo.landscape{max-width:160px}
 .social-icons{list-style:none;margin:2em auto;text-align:center}.social-icons li{display:inline-block;margin:0 1em}
 .profile .social-icons{margin:1em 0}.profile .social-icons li{margin:0 .5em}.social-icons a{display:block}
 .social-icons a svg{fill:#fefefe;width:42px;height:42px}.profile .social-icons a svg{width:32px;height:32px;fill:#d66315}


### PR DESCRIPTION
This renames sponsor related classes to `partner` in an effort to stop ad blockers from blocking sponsor logos and DOM elements.

It does not rename the underlying data or loops in Jekyll, which may also be desired.