### PR TITLE
Fixes #106. Provides padding before anchors when they are targeted.

### DIFF
--- a/_scss/base/_global.scss
+++ b/_scss/base/_global.scss
@@ -54,3 +54,16 @@ iframe,
 .callout-dark {
   @include callout-style(darken($dark-green, 5%));
 }
+
+// Ensure we have space for anchors and the header does not cover them.
+:target:before {
+  display:block;
+  margin: -70px 0 0; /* negative fixed header height */
+  height: 70px; /* fixed header height*/
+  content: "";
+
+  @include breakpoint(medium) {
+    margin-top: -110px;
+    height: 110px;
+  }
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -755,8 +755,9 @@ h1 a,h2 a,.partner-footer h3 a,h3 a,h4 a,h5 a,h6 a{text-decoration:none}li{margi
 .lead{margin-bottom:2.5rem;font-weight:400}.lead.min{margin-bottom:1.5rem}.demp{font-weight:400}
 iframe,.highlighter-rouge{margin-bottom:1rem}.responsive-embed iframe{margin-bottom:0}
 .thumbnail-block{border-radius:0}@media print,screen and (min-width:55.625em){.list-split{display:-ms-flexbox;display:flex;-ms-flex-flow:row wrap;flex-flow:row wrap;-ms-flex-pack:justify;justify-content:space-between}
-.list-split li{width:45%}}.callout-dark{background-color:#072a1c;color:#f1dfc7}.button{text-decoration:none}
-.button+.button{margin-left:.5em}.button.secondary,.button.secondary:hover{color:#fefefe}
+.list-split li{width:45%}}.callout-dark{background-color:#072a1c;color:#f1dfc7}:target:before{display:block;margin:-70px 0 0;height:70px;content:""}
+@media print,screen and (min-width:55.625em){:target:before{margin-top:-110px;height:110px}
+}.button{text-decoration:none}.button+.button{margin-left:.5em}.button.secondary,.button.secondary:hover{color:#fefefe}
 .event-page h1{margin-bottom:.5rem}.menu a{color:#fefefe;text-decoration:none}.headroom--top .menu .menu,.menu .menu{text-align:left}
 .headroom--top .menu .menu a,.menu .menu a{color:#fefefe}.headroom--top .menu .menu a:hover,.menu .menu a:hover{background:#d66315}
 .headroom--top .menu .navbar-button,.navbar-button{padding-top:.4rem;padding-bottom:.4rem;background:#d66315;color:#fefefe;text-align:center;line-height:1.1}


### PR DESCRIPTION
This creates a pseudo element before any targeted anchor. It is small and medium+ size aware.

Results are not exact, but space should be provided in most cases. Note this might not work well with full color content blocks. It's best suited for long form pages.

This was my primary test case: https://2017.djangocon.us/financial-aid/#frequently-asked-questions

Original issue here: https://github.com/djangocon/2017.djangocon.us/issues/106

