### PR TITLE
Tiny typo fix.

### DIFF
--- a/_posts/2017-05-19-announcing-talk-lineup.md
+++ b/_posts/2017-05-19-announcing-talk-lineup.md
@@ -51,4 +51,4 @@ We’ll also announce the tutorial schedule in just a few days, and the conferen
  * The 10 Commandments of Community Organizing (Jennifer Wadella)
  * Exhausted Octopus Learns a Thing!! (Laura R. Webb)
  * The Denormalized Query Engine Design Pattern (Simon Willison)
- * Tasks: You Gotta Know How to Run 'Em, You Gotta Know How to Save ’Em (Filipe Ximenes)
+ * Tasks: You Gotta Know How to Run 'Em, You Gotta Know How to Safe ’Em (Filipe Ximenes)


### PR DESCRIPTION
The speaker has replied to an email confirming this is actually correct! It is "Safe" and not "Save".