### PR TITLE
Indicating early bird tickets are sold out

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -53,6 +53,8 @@
 <li class="has-button">
   <a class="navbar-button" href="https://ti.to/defna/djangocon-us-2017">
     <strong>Buy Tickets</strong><br>
+    {% comment %}
     <small>Early Bird Pricing Available</small>
+    {% endcomment %}
   </a>
 </li>

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -25,8 +25,8 @@ description: Information about buying tickets to DjangoCon US
 <div class="content">
   <nav class="row column v-pad-bottom">
    <h2>Ticket Prices</h2>
-    <p><strong>Individual ($345 early bird, $445 regular)</strong>: If your company has 5 or fewer employees, or if you’re purchasing your own ticket without any help from your employer.</p>
-    <p><strong>Corporate ($545 early bird, $645 regular)</strong>: If your employer (with more than 5 employees) is paying for your ticket. State or government institutions should use the corporate rate if they are able.</p>
+    <p><strong>Individual ($345 early bird (sold out), $445 regular)</strong>: If your company has 5 or fewer employees, or if you’re purchasing your own ticket without any help from your employer.</p>
+    <p><strong>Corporate ($545 early bird (sold out), $645 regular)</strong>: If your employer (with more than 5 employees) is paying for your ticket. State or government institutions should use the corporate rate if they are able.</p>
     <p><strong>Student/Diversity ($245)</strong>: If you’re unemployed, on a lower income, are a member of an underrepresented group, or would benefit from a lower-priced ticket for another reason.</p>
     <p><strong>Tutorials ($150)</strong>: They are a separate cost from your conference ticket. You can register for a tutorial without registering for the conference itself. You must register for a specific tutorial.</p>
     <p><strong>Sprints (free)</strong>: The ticket is free, but we ask you to register so we can buy you lunch. You do not have to register for the conference itself to register for sprints.</p>


### PR DESCRIPTION
Navbar text became larger when small text was removed. Seems ok. Not sure if this is an adequate update on the ticket page. Am open to other ideas. 