### PR TITLE
Updates navbar menu spacing

### DIFF
--- a/_scss/layout/_navbar.scss
+++ b/_scss/layout/_navbar.scss
@@ -3,9 +3,13 @@
 // Documentation here: http://wicky.nillia.ms/headroom.js/
 
 // title bar text overrides
-.menu  a {
-  color: $white;
+.menu a {
   text-decoration: none;
+  color: $white;
+}
+
+.dropdown .menu li {
+  margin-bottom: 0;
 }
 
 // If you want to only have the transparent-at-top option on the homepage

--- a/_scss/layout/_navbar.scss
+++ b/_scss/layout/_navbar.scss
@@ -2,8 +2,10 @@
 // it adds classes with JS, and those classes are used here.
 // Documentation here: http://wicky.nillia.ms/headroom.js/
 
+
+
 // title bar text overrides
-.menu a {
+.title-bar .menu a {
   text-decoration: none;
   color: $white;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -758,9 +758,10 @@ li{margin-bottom:.85rem}.lead{margin-bottom:2.5rem;font-weight:400}.lead.min{mar
 .list-split li{width:45%}}.callout-dark{background-color:#072a1c;color:#f1dfc7}:target:before{display:block;margin:-70px 0 0;height:70px;content:""}
 @media print,screen and (min-width:55.625em){:target:before{margin-top:-110px;height:110px}
 }.button{text-decoration:none}.button+.button{margin-left:.5em}.button.secondary,.button.secondary:hover{color:#fefefe}
-.event-page h1{margin-bottom:.5rem}.menu a{text-decoration:none;color:#fefefe}.dropdown .menu li{margin-bottom:0}
-.headroom--top .menu .menu,.menu .menu{text-align:left}.headroom--top .menu .menu a,.menu .menu a{color:#fefefe}
-.headroom--top .menu .menu a:hover,.menu .menu a:hover{background:#d66315}.headroom--top .menu .navbar-button,.navbar-button{padding-top:.4rem;padding-bottom:.4rem;background:#d66315;color:#fefefe;text-align:center;line-height:1.1}
+.event-page h1{margin-bottom:.5rem}.title-bar .menu a{text-decoration:none;color:#fefefe}
+.dropdown .menu li{margin-bottom:0}.headroom--top .menu .menu,.menu .menu{text-align:left}
+.headroom--top .menu .menu a,.menu .menu a{color:#fefefe}.headroom--top .menu .menu a:hover,.menu .menu a:hover{background:#d66315}
+.headroom--top .menu .navbar-button,.navbar-button{padding-top:.4rem;padding-bottom:.4rem;background:#d66315;color:#fefefe;text-align:center;line-height:1.1}
 .headroom--top .menu .navbar-button small,.navbar-button small{font-size:.76923rem}
 .headroom--top .menu .navbar-button:hover,.navbar-button:hover{background:#c15913}
 .logo{width:160px;display:block;margin:10px 0 -20px 10px;height:53px}.logo svg{max-width:100%;height:100%}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -302,8 +302,8 @@ h2,.partner-footer h3,h3{page-break-after:avoid}}.button{display:inline-block;ve
 .button.arrow-only::after{top:-0.1em;float:none;margin-left:0}[type='text'],[type='password'],[type='date'],[type='datetime'],[type='datetime-local'],[type='month'],[type='week'],[type='email'],[type='number'],[type='search'],[type='tel'],[type='time'],[type='url'],[type='color'],textarea{display:block;box-sizing:border-box;width:100%;height:1.875rem;margin:0 0 .76923rem;padding:.38462rem;border:1px solid #cacaca;border-radius:0;background-color:#fefefe;box-shadow:inset 0 1px 2px rgba(10,10,10,0.1);font-family:inherit;font-size:.76923rem;font-weight:400;color:#0a0a0a;transition:box-shadow .5s,border-color .25s ease-in-out;-webkit-appearance:none;-moz-appearance:none;appearance:none}
 [type='text']:focus,[type='password']:focus,[type='date']:focus,[type='datetime']:focus,[type='datetime-local']:focus,[type='month']:focus,[type='week']:focus,[type='email']:focus,[type='number']:focus,[type='search']:focus,[type='tel']:focus,[type='time']:focus,[type='url']:focus,[type='color']:focus,textarea:focus{outline:0;border:1px solid #8a8a8a;background-color:#fefefe;box-shadow:0 0 5px #cacaca;transition:box-shadow .5s,border-color .25s ease-in-out}
 textarea{max-width:100%}textarea[rows]{height:auto}input::-webkit-input-placeholder,textarea::-webkit-input-placeholder{color:#cacaca}
-input:-ms-input-placeholder,textarea:-ms-input-placeholder{color:#cacaca}input::placeholder,textarea::placeholder{color:#cacaca}
-input:disabled,input[readonly],textarea:disabled,textarea[readonly]{background-color:#e6e6e6;cursor:not-allowed}
+input::-moz-placeholder,textarea::-moz-placeholder{color:#cacaca}input:-ms-input-placeholder,textarea:-ms-input-placeholder{color:#cacaca}
+input::placeholder,textarea::placeholder{color:#cacaca}input:disabled,input[readonly],textarea:disabled,textarea[readonly]{background-color:#e6e6e6;cursor:not-allowed}
 [type='submit'],[type='button']{-webkit-appearance:none;-moz-appearance:none;appearance:none;border-radius:0}
 input[type='search']{box-sizing:border-box}[type='file'],[type='checkbox'],[type='radio']{margin:0 0 .76923rem}
 [type='checkbox']+label,[type='radio']+label{display:inline-block;vertical-align:baseline;margin-left:.38462rem;margin-right:.76923rem;margin-bottom:0}
@@ -325,9 +325,9 @@ select{height:1.875rem;margin:0 0 .76923rem;padding:.38462rem;-webkit-appearance
 }select:focus{outline:0;border:1px solid #8a8a8a;background-color:#fefefe;box-shadow:0 0 5px #cacaca;transition:box-shadow .5s,border-color .25s ease-in-out}
 select:disabled{background-color:#e6e6e6;cursor:not-allowed}select::-ms-expand{display:none}
 select[multiple]{height:auto;background-image:none}.is-invalid-input:not(:focus){border-color:#cc4b37;background-color:#f9ecea}
-.is-invalid-input:not(:focus)::-webkit-input-placeholder{color:#cc4b37}.is-invalid-input:not(:focus):-ms-input-placeholder{color:#cc4b37}
-.is-invalid-input:not(:focus)::placeholder{color:#cc4b37}.is-invalid-label{color:#cc4b37}
-.form-error{display:none;margin-top:-0.38462rem;margin-bottom:.76923rem;font-size:.57692rem;font-weight:500;color:#cc4b37}
+.is-invalid-input:not(:focus)::-webkit-input-placeholder{color:#cc4b37}.is-invalid-input:not(:focus)::-moz-placeholder{color:#cc4b37}
+.is-invalid-input:not(:focus):-ms-input-placeholder{color:#cc4b37}.is-invalid-input:not(:focus)::placeholder{color:#cc4b37}
+.is-invalid-label{color:#cc4b37}.form-error{display:none;margin-top:-0.38462rem;margin-bottom:.76923rem;font-size:.57692rem;font-weight:500;color:#cc4b37}
 .form-error.is-visible{display:block}.hide{display:none !important}.invisible{visibility:hidden}
 @media screen and (max-width:32.6875em){.hide-for-small-only{display:none !important}
 }@media screen and (max-width:0),screen and (min-width:32.75em){.show-for-small-only{display:none !important}
@@ -758,9 +758,9 @@ li{margin-bottom:.85rem}.lead{margin-bottom:2.5rem;font-weight:400}.lead.min{mar
 .list-split li{width:45%}}.callout-dark{background-color:#072a1c;color:#f1dfc7}:target:before{display:block;margin:-70px 0 0;height:70px;content:""}
 @media print,screen and (min-width:55.625em){:target:before{margin-top:-110px;height:110px}
 }.button{text-decoration:none}.button+.button{margin-left:.5em}.button.secondary,.button.secondary:hover{color:#fefefe}
-.event-page h1{margin-bottom:.5rem}.menu a{color:#fefefe;text-decoration:none}.headroom--top .menu .menu,.menu .menu{text-align:left}
-.headroom--top .menu .menu a,.menu .menu a{color:#fefefe}.headroom--top .menu .menu a:hover,.menu .menu a:hover{background:#d66315}
-.headroom--top .menu .navbar-button,.navbar-button{padding-top:.4rem;padding-bottom:.4rem;background:#d66315;color:#fefefe;text-align:center;line-height:1.1}
+.event-page h1{margin-bottom:.5rem}.menu a{text-decoration:none;color:#fefefe}.dropdown .menu li{margin-bottom:0}
+.headroom--top .menu .menu,.menu .menu{text-align:left}.headroom--top .menu .menu a,.menu .menu a{color:#fefefe}
+.headroom--top .menu .menu a:hover,.menu .menu a:hover{background:#d66315}.headroom--top .menu .navbar-button,.navbar-button{padding-top:.4rem;padding-bottom:.4rem;background:#d66315;color:#fefefe;text-align:center;line-height:1.1}
 .headroom--top .menu .navbar-button small,.navbar-button small{font-size:.76923rem}
 .headroom--top .menu .navbar-button:hover,.navbar-button:hover{background:#c15913}
 .logo{width:160px;display:block;margin:10px 0 -20px 10px;height:53px}.logo svg{max-width:100%;height:100%}


### PR DESCRIPTION
This fixes 2 problems:

1. It narrows menu styles to the title bar, since `.menu` is kind of generic.
2. It tightens up the spacing between items in the drop down menus (screenshots below).

Before:
<img width="384" alt="screenshot 2017-08-11 12 14 32" src="https://user-images.githubusercontent.com/84750/29221964-a6809fc0-7e8e-11e7-8e8c-f9696b1f0021.png">

After:

<img width="363" alt="screenshot 2017-08-11 12 13 07" src="https://user-images.githubusercontent.com/84750/29221972-ac43bd70-7e8e-11e7-9f58-ea99aec02948.png">

The spacing isn't so much of an issue, as how it's implemented. It's literal margin, meaning you can't click anything. Tightening up the spacing not only looks better but creates less confusion (user could click, nothing would happen).